### PR TITLE
Feat: Issue #23: On a push event set the commit status to pending

### DIFF
--- a/src/main/java/fundamentals/server/ContinuousIntegrationServer.java
+++ b/src/main/java/fundamentals/server/ContinuousIntegrationServer.java
@@ -9,6 +9,7 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 public class ContinuousIntegrationServer {
 
     final static int DEFAULT_PORT_NUMBER = 8014;
+    final static Environment environment = Environment.loadEnvironmentFile();
 
     static int getPortNumberFromInputOrElseDefault(String[] args) {
         try {
@@ -31,7 +32,7 @@ public class ContinuousIntegrationServer {
 
     static ContextHandlerCollection getEndpointsHandler() {
         var endpoints = new ContextHandlerCollection();
-        endpoints.addHandler(getContextHandler("/webhook", new WebhookHandler()));
+        endpoints.addHandler(getContextHandler("/webhook", new WebhookHandler(environment)));
         endpoints.addHandler(getContextHandler("/build/all", new BuildAllHandler()));
         endpoints.addHandler(getContextHandler("/build", new BuildHandler()));
         return endpoints;

--- a/src/main/java/fundamentals/server/WebhookHandler.java
+++ b/src/main/java/fundamentals/server/WebhookHandler.java
@@ -13,6 +13,12 @@ import java.io.InputStreamReader;
 
 public class WebhookHandler extends AbstractHandler {
 
+    private final Environment environment;
+
+    public WebhookHandler(Environment environment) {
+        this.environment = environment;
+    }
+
     @Override
     public void handle(String target,
                        Request baseRequest,
@@ -61,7 +67,19 @@ public class WebhookHandler extends AbstractHandler {
 
             // TODO:
             // Create a build ID, build date and set build status = pending. Store this in a JSON file and keep it in main-memory.
+
             // Set the commit status to pending on Github.
+            String username = environment.getValue("USERNAME");
+            String personalAccessToken  = environment.getValue("PERSONAL_ACCESS_TOKEN");
+            GithubCommitAPI api = new GithubCommitAPI(owner, repository, commitSha, username, personalAccessToken);
+            GithubCommitAPIRequest apiRequest = api.setCommitStatusPending("Compiling and running tests...", "");
+
+            if (apiRequest.send()) {
+                System.out.println("Updated commit status to pending for commit: " + commitSha);
+            } else {
+                System.out.println("Failed to update commit status for: " + commitSha);
+            }
+
             // On a background thread compile and test the repo.
             // When the background thread is done, update build logs, build status, etc in the JSON file and main memory.
             // Update the commit status on Github.


### PR DESCRIPTION
When we receive a push event from Github we will set the commit status to `pending` to indicate that we will compile the code and run tests. I used the `GithubCommitAPI` to do this. 