### PR TITLE
Feat: Issue #35: Add support for executing tests in webhook handler

### DIFF
--- a/src/main/java/fundamentals/server/ContinuousIntegrationServer.java
+++ b/src/main/java/fundamentals/server/ContinuousIntegrationServer.java
@@ -10,6 +10,7 @@ public class ContinuousIntegrationServer {
 
     final static int DEFAULT_PORT_NUMBER = 8014;
     final static BuildStorage storage = BuildStorage.loadBuildStorageFile();
+    final static Environment env = Environment.loadEnvironmentFile();
 
     static int getPortNumberFromInputOrElseDefault(String[] args) {
         try {
@@ -32,7 +33,7 @@ public class ContinuousIntegrationServer {
 
     static ContextHandlerCollection getEndpointsHandler() {
         var endpoints = new ContextHandlerCollection();
-        endpoints.addHandler(getContextHandler("/webhook", new WebhookHandler(storage)));
+        endpoints.addHandler(getContextHandler("/webhook", new WebhookHandler(env, storage)));
         endpoints.addHandler(getContextHandler("/build/all", new BuildAllHandler(storage)));
         endpoints.addHandler(getContextHandler("/build", new BuildHandler(storage)));
         return endpoints;

--- a/src/main/java/fundamentals/server/WebhookHandler.java
+++ b/src/main/java/fundamentals/server/WebhookHandler.java
@@ -1,5 +1,6 @@
 package fundamentals.server;
 
+import fundamentals.server.helpers.Bash;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -70,6 +71,20 @@ public class WebhookHandler extends AbstractHandler {
 
             // Create a build ID, build date and set build status = pending. Store this in a JSONObject in main-memory.
             JSONObject newBuild = storage.addNewBuild(owner, repository, commitHash);
+
+            RepoManager manager = new RepoManager(body.toString(), env);
+            Tester tester = new Tester(manager.repoDir, new Bash());
+
+            manager.cloneRepo();
+            manager.checkoutBranch();
+            Boolean successful = tester.run();
+            manager.cleanUp();
+
+            if (successful) {
+                System.out.println("testsuite executed without any failures");
+            } else {
+                System.out.println("testsuite failed");
+            }
 
             // TODO:
             // Set the commit status to pending on Github.

--- a/src/main/java/fundamentals/server/WebhookHandler.java
+++ b/src/main/java/fundamentals/server/WebhookHandler.java
@@ -15,8 +15,11 @@ public class WebhookHandler extends AbstractHandler {
 
     private final BuildStorage storage;
 
-    public WebhookHandler(BuildStorage storage) {
+    private final Environment env;
+
+    public WebhookHandler(Environment env, BuildStorage storage) {
         this.storage = storage;
+        this.env = env;
     }
 
     @Override


### PR DESCRIPTION
Running the following command will trigger the testsuite to run

```bash
curl -X POST localhost:8014/webhook/  -H "X-GitHub-Event: push" -H 'Content-Type: application/json' -d '{"after":"","repository":{"name":"ci-server", "owner":{"name":""},"clone_url":"https://github.com/Fundamentals-KTH-CSC-2022-P3/ci-server.git"},"ref":"refs/heads/main"}'
```