### PR TITLE
Feat: Issue #51: Add a GUI to visualize the builds

### DIFF
--- a/public/build.html
+++ b/public/build.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CI Server</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap" rel="stylesheet">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p {
+            font-family: 'Roboto', sans-serif;
+            color: rgb(49, 49, 49);
+        }
+
+        h1 {
+            font-size: 2.4rem;
+            font-weight: 300;
+        }
+
+        p {
+            font-weight: 500;
+        }
+
+        .container {
+            width: 100%;
+            height: auto;
+        }
+
+        .header {
+            padding: 24px 8px;
+            border-bottom: 1px solid #ccc;
+        }
+
+        .build-part {
+            font-size: 70%;
+        }
+
+        .inner-header {
+            max-width: 1600px;
+            margin: auto;
+        }
+
+        .content {
+            margin-top: 24px;
+            padding: 8px;
+        }
+
+        .inner-content {
+            max-width: 1600px;
+            margin: auto;
+        }
+
+        .build-info-row {
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .build-info-cell {
+            margin-bottom: 24px;
+        }
+
+        .build-info-label {
+            font-size: 0.9rem;
+            padding-bottom: 2px;
+        }
+
+        .build-info-value {
+            font-size: 1.2rem;
+        }
+
+        .build-logs {
+            margin-top: 24px;
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .compile-logs {
+            width: 49%;
+            background-color: #f5f5f5;
+            border: 1px solid #ccc;
+        }
+
+        .test-logs {
+            width: 49%;
+            background-color: #f5f5f5;
+            border: 1px solid #ccc;
+        }
+
+        .log-title {
+            font-size: 1.2rem;
+            font-weight: 500;
+            padding: 12px;
+            border-bottom: 1px solid #ccc;
+            background-color: #fff;
+        }
+
+        .log-area {
+            width: 100%;
+            height: 500px;
+            padding: 8px;
+            box-sizing: border-box;
+            overflow-y: scroll;
+        }
+
+        .log-area p {
+            font-size: 0.9rem;
+            font-family: "Consolas";
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <header class="header">
+            <div class="inner-header">
+                <h1>CI Server / <span class="build-part">build / <span
+                            class="build-id">03c94d9a-d994-475e-be1a-6229b68e315f</span></span></h1>
+            </div>
+        </header>
+        <div class="content">
+            <div class="inner-content">
+                <div class="build-info-row">
+                    <div class="build-info-col">
+                        <div class="build-info-cell">
+                            <p class="build-info-label">Owner</p>
+                            <p class="build-info-value owner">Fundamentals-KTH-CSC-2022-P3</p>
+                        </div>
+                        <div class="build-info-cell">
+                            <p class="build-info-label">Build status</p>
+                            <p class="build-info-value build-status">Pending</p>
+                        </div>
+                    </div>
+                    <div class="build-info-col">
+                        <div class="build-info-cell">
+                            <p class="build-info-label">Repository</p>
+                            <p class="build-info-value repository">set-commit-status-test</p>
+                        </div>
+                        <div class="build-info-cell">
+                            <p class="build-info-label">Build started</p>
+                            <p class="build-info-value build-started">2022-02-09T14:39:06.099022900Z</p>
+                        </div>
+                    </div>
+                    <div class="build-info-col">
+                        <div class="build-info-cell">
+                            <p class="build-info-label">Commit</p>
+                            <p class="build-info-value commit">57078cb22a033227928f33cfff0328ee80fa3b35</p>
+                        </div>
+                        <div class="build-info-cell">
+                            <p class="build-info-label">Build ended</p>
+                            <p class="build-info-value build-ended">Not yet</p>
+                        </div>
+                    </div>
+                    <div class="build-info-col">
+                        <p class="build-info-label">Branch</p>
+                        <p class="build-info-value branch">main</p>
+                    </div>
+                </div>
+
+                <div class="build-logs">
+                    <div class="compile-logs">
+                        <h2 class="log-title">Compile logs</h2>
+                        <div class="log-area compile-logs-area">
+                        </div>
+                    </div>
+                    <div class="test-logs">
+                        <h2 class="log-title">Test logs</h2>
+                        <div class="log-area test-logs-area">
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+
+        const contentElement = document.querySelector('.content');
+        contentElement.style.display = 'none';
+
+        // Set the color of the build status text pending on its value.
+        function setBuildStatusColor() {
+            const buildStatus = document.querySelector('.build-status');
+            switch (buildStatus.innerHTML.toLowerCase()) {
+                case 'pending':
+                    buildStatus.style.color = '#db750b';
+                    break;
+                case 'success':
+                    buildStatus.style.color = '#46db0b';
+                    break;
+                case 'error':
+                case 'failure':
+                    buildStatus.style.color = '#db190b';
+                    break;
+            }
+        }
+
+        // Fetch JSON data about a specific build and set the corresponding values in the HTML document.
+        async function fetchData() {
+            const pathParts = window.location.pathname.split('/');
+            const buildID = pathParts[pathParts.length - 1];
+            document.querySelector('.build-id').innerHTML = buildID;
+            
+            response = await fetch('http://ci.alevarn.com/build/' + buildID);
+            
+            console.log(response);
+
+            if (!response.ok) {
+                contentElement.innerHTML = `<h1 style="text-align:center;">A build with ID "${buildID}" does not exist</h1>`;
+            } else {
+                const buildInfo = await response.json();
+
+                document.querySelector('.owner').innerHTML = buildInfo['owner'];
+                document.querySelector('.repository').innerHTML = buildInfo['repository'];
+                document.querySelector('.commit').innerHTML = buildInfo['commit'];
+                document.querySelector('.build-started').innerHTML = buildInfo['build_started'];
+                document.querySelector('.build-ended').innerHTML = buildInfo['build_ended'];
+                document.querySelector('.branch').innerHTML = buildInfo['branch'];
+
+                if (buildInfo['compile_status'] == 'pending' || buildInfo['test_status'] == 'pending') {
+                    document.querySelector('.build-status').innerHTML = 'Pending';
+                } else if (buildInfo['compile_status'] == 'success' && buildInfo['test_status'] == 'success') {
+                    document.querySelector('.build-status').innerHTML = 'Success';
+                } else if (buildInfo['compile_status'] == 'error') {
+                    document.querySelector('.build-status').innerHTML = 'Error';
+                } else {
+                    // Tests must have failed.
+                    document.querySelector('.build-status').innerHTML = 'Failure';
+                }
+
+                setBuildStatusColor();
+
+                const compileLogsArea = document.querySelector('.compile-logs-area');
+                const testLogsArea = document.querySelector('.test-logs-area');
+
+                buildInfo['compile_logs'].forEach(log => compileLogsArea.innerHTML += `<p>&gt; ${log}</p>`);
+                buildInfo['test_logs'].forEach(log => testLogsArea.innerHTML += `<p>&gt; ${log}</p>`);
+            }
+
+            contentElement.style.display = 'block';
+        }
+
+        fetchData();
+
+    </script>
+</body>
+
+</html>

--- a/public/build_all.html
+++ b/public/build_all.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CI Server</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap" rel="stylesheet">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p {
+            font-family: 'Roboto', sans-serif;
+            color: rgb(49, 49, 49);
+        }
+
+        a {
+            font-family: 'Roboto', sans-serif;
+            color:#0066ff;
+        }
+
+        h1 {
+            font-size: 2.4rem;
+            font-weight: 300;
+        }
+
+        p {
+            font-weight: 500;
+        }
+
+        .container {
+            width: 100%;
+            height: auto;
+        }
+
+        .header {
+            padding: 24px 8px;
+            border-bottom: 1px solid #ccc;
+        }
+
+        .build-part {
+            font-size: 70%;
+        }
+
+        .inner-header {
+            max-width: 1600px;
+            margin: auto;
+        }
+
+        .content {
+            margin-top: 24px;
+            padding: 8px;
+        }
+
+        .inner-content {
+            max-width: 1600px;
+            margin: auto;
+        }
+
+        .build-list {
+            list-style: none;
+        }
+
+        .build-item {
+            display: flex;
+            justify-content: space-between;
+            border: 1px solid #ccc;
+            margin-bottom: 16px;
+            padding: 16px;
+        }
+
+        .build-info-label {
+            font-size: 0.9rem;
+            padding-bottom: 2px;
+        }
+
+        .build-info-value {
+            font-size: 1rem;
+        }
+
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <header class="header">
+            <div class="inner-header">
+                <h1>CI Server / <span class="build-part">build / all</span></h1>
+            </div>
+        </header>
+        <div class="content">
+            <div class="inner-content">
+                <ul class="build-list">
+                   
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <script>
+
+        // Fetch JSON data about all builds and create a list with information about these builds.
+        async function fetchData() {
+            response = await fetch('http://ci.alevarn.com/build/all');
+            
+            buildsInfo = await response.json();
+        
+            const buildListElement = document.querySelector('.build-list');
+
+            buildsInfo.forEach(buildInfo => {
+                const buildID = buildInfo['build_id'];
+                const owner = buildInfo['owner'];
+                const repository = buildInfo['repository'];
+                const branch = buildInfo['branch'];
+                const buildStarted = buildInfo['build_started'];
+                
+                buildListElement.innerHTML += 
+                `<li class="build-item">
+                    <div class="build-info-col">
+                            <p class="build-info-label">Build ID</p>
+                            <p class="build-info-value"><a href="http://ci.alevarn.com/ui/build/${buildID}">${buildID}</a></p>
+                        </div>
+                        <div class="build-info-col">
+                            <p class="build-info-label">Owner</p>
+                            <p class="build-info-value">${owner}</p>
+                        </div>
+                        <div class="build-info-col">
+                            <p class="build-info-label">Repository</p>
+                            <p class="build-info-value">${repository}</p>
+                        </div>
+                        <div class="build-info-col">
+                            <p class="build-info-label">Branch</p>
+                            <p class="build-info-value">${branch}</p>
+                        </div>
+                        <div class="build-info-col">
+                            <p class="build-info-label">Build started</p>
+                            <p class="build-info-value">${buildStarted}</p>
+                        </div>
+                </li>`
+            });
+        }
+
+        fetchData();
+
+    </script>
+</body>
+
+</html>

--- a/src/main/java/fundamentals/server/BuildStorage.java
+++ b/src/main/java/fundamentals/server/BuildStorage.java
@@ -90,11 +90,12 @@ public class BuildStorage {
      * added your build.
      *
      * @param owner      the owner of the repository.
+     * @param branch     the branch.
      * @param repository the repository.
      * @param commitHash the commit hash.
      * @return an object of type {@code JSONObject} that contains information about the current build.
      */
-    public synchronized JSONObject addNewBuild(String owner, String repository, String commitHash) {
+    public synchronized JSONObject addNewBuild(String owner, String repository, String branch, String commitHash) {
         JSONObject build = new JSONObject();
 
         // Generate a unique identifier for this build.
@@ -103,9 +104,10 @@ public class BuildStorage {
         // The information we will store about each build.
         build.put("build_id", buildID);
         build.put("owner", owner);
+        build.put("branch", branch);
         build.put("repository", repository);
         build.put("commit", commitHash);
-        build.put("build_started", new SimpleDateFormat("").format(new Date()));
+        build.put("build_started", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()));
         build.put("build_ended", "not yet");
         build.put("compile_status", "pending");
         build.put("test_status", "pending");

--- a/src/main/java/fundamentals/server/BuildStorage.java
+++ b/src/main/java/fundamentals/server/BuildStorage.java
@@ -5,7 +5,8 @@ import org.json.JSONObject;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -104,7 +105,7 @@ public class BuildStorage {
         build.put("owner", owner);
         build.put("repository", repository);
         build.put("commit", commitHash);
-        build.put("build_started", Instant.now().toString());
+        build.put("build_started", new SimpleDateFormat("").format(new Date()));
         build.put("build_ended", "not yet");
         build.put("compile_status", "pending");
         build.put("test_status", "pending");

--- a/src/main/java/fundamentals/server/ContinuousIntegrationServer.java
+++ b/src/main/java/fundamentals/server/ContinuousIntegrationServer.java
@@ -1,8 +1,6 @@
 package fundamentals.server;
 
-import fundamentals.server.handlers.BuildAllHandler;
-import fundamentals.server.handlers.BuildHandler;
-import fundamentals.server.handlers.WebhookHandler;
+import fundamentals.server.handlers.*;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
@@ -38,7 +36,8 @@ public class ContinuousIntegrationServer {
 
     /**
      * Wraps and returns the provided handler in a context handler with a set path
-     * @param path the relative path to which the context should be bound to.
+     *
+     * @param path    the relative path to which the context should be bound to.
      * @param handler An already initialized handler which is to be wrapped
      */
     static Handler getContextHandler(String path, Handler handler) {
@@ -52,7 +51,8 @@ public class ContinuousIntegrationServer {
     /**
      * Wraps and returns the provided handler in a context handler with the relative path set, which in turn is
      * wrapped by a basic auth security handler bound by the single role admin.
-     * @param path the relative path to which the context should be bound to.
+     *
+     * @param path    the relative path to which the context should be bound to.
      * @param handler An already initialized handler which is to be wrapped
      */
     static Handler getSecureHandler(String path, Handler handler) {
@@ -78,6 +78,7 @@ public class ContinuousIntegrationServer {
 
     /**
      * Initiates and returns a collection of enpoints which have yet to be registered with any server
+     *
      * @return A collection of handlers with paths preregistered
      */
     static ContextHandlerCollection getEndpointsHandler() {
@@ -85,11 +86,14 @@ public class ContinuousIntegrationServer {
         endpoints.addHandler(getContextHandler("/webhook", new WebhookHandler(environment, storage)));
         endpoints.addHandler(getSecureHandler("/build/all", new BuildAllHandler(storage)));
         endpoints.addHandler(getSecureHandler("/build", new BuildHandler(storage)));
+        endpoints.addHandler(getSecureHandler("/ui/build/all", new UIBuildAllHandler()));
+        endpoints.addHandler(getSecureHandler("/ui/build", new UIBuildHandler()));
         return endpoints;
     }
 
     /**
      * Start the server, simple as.
+     *
      * @param args the port number can be specified in args. If none is given, DEFAULT_PORT_NUMBER is used.
      * @throws Exception if the server is interrupted.
      */

--- a/src/main/java/fundamentals/server/Environment.java
+++ b/src/main/java/fundamentals/server/Environment.java
@@ -66,7 +66,7 @@ public class Environment {
     }
 
     public static String loadEnvironmentVariableOrElse(String environmentVariableName, String orElse) {
-        var sysVariable  = System.getenv(environmentVariableName);
+        var sysVariable = System.getenv(environmentVariableName);
         if (sysVariable == null) {
             return orElse;
         }

--- a/src/main/java/fundamentals/server/Tester.java
+++ b/src/main/java/fundamentals/server/Tester.java
@@ -3,6 +3,7 @@ package fundamentals.server;
 import fundamentals.server.helpers.Bash;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Takes the POST:ed payload string from a GitHub push webhook and clones the repository specified in the payload.
@@ -17,6 +18,7 @@ public class Tester {
     /**
      * Takes a RepoManager that is connected to the repo to test, and tests the repo, reporting any
      * failures.
+     *
      * @param repoDir the root of the local copy of the repository to test
      */
     public Tester(File repoDir, Bash shell) {
@@ -26,11 +28,27 @@ public class Tester {
 
     /**
      * Runs the tests via maven in the repo
+     *
      * @return true if the tests succeeded, false otherwise
      */
     public boolean run() {
-        String[] mavenCmd = {"mvn", "test"};
-        System.out.println("running maven");
+        String[] mavenCmd;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            mavenCmd = new String[] {"mvn.cmd", "test"};
+        } else {
+            mavenCmd = new String[] {"mvn", "test"};
+        }
+
         return this.shell.execute(mavenCmd, null, repoDir);
+    }
+
+    /**
+     * Get the output from the test command
+     *
+     * @return a list of the lines of the test output
+     */
+    public List<String> getTestOutput() {
+        return shell.getStdout();
     }
 }

--- a/src/main/java/fundamentals/server/gitTooling/RepoManager.java
+++ b/src/main/java/fundamentals/server/gitTooling/RepoManager.java
@@ -23,6 +23,7 @@ public class RepoManager {
 
     /**
      * Create a RepoManager that manages the specified repository.
+     *
      * @param payload The payload provided by the GitHub webhook
      */
     public RepoManager(String payload, Environment environment) throws IOException {
@@ -89,8 +90,6 @@ public class RepoManager {
             System.err.println("Error running git clone in " + parentDir.getAbsolutePath());
             ioException.printStackTrace();
         }
-
-        checkoutBranch();
     }
 
     /**
@@ -119,6 +118,7 @@ public class RepoManager {
 
     /**
      * Delete a file, or recursively delete a directory
+     *
      * @param file the file or directory to be deleted
      */
     static void deleteDirectory(File file) {

--- a/src/main/java/fundamentals/server/handlers/UIBuildAllHandler.java
+++ b/src/main/java/fundamentals/server/handlers/UIBuildAllHandler.java
@@ -1,0 +1,37 @@
+package fundamentals.server.handlers;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+/**
+ * Will handle the endpoint "/ui/build/all" and will send the build_all.html file back to the user.
+ */
+public class UIBuildAllHandler extends AbstractHandler {
+
+    public static final String UI_BUILD_FILE = "public/build_all.html";
+
+    @Override
+    public void handle(String target,
+                       Request baseRequest,
+                       HttpServletRequest request,
+                       HttpServletResponse response)
+            throws IOException, ServletException {
+        response.setContentType("text/html;charset=utf-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        baseRequest.setHandled(true);
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(UI_BUILD_FILE))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                response.getWriter().println(line);
+            }
+        }
+    }
+}

--- a/src/main/java/fundamentals/server/handlers/UIBuildHandler.java
+++ b/src/main/java/fundamentals/server/handlers/UIBuildHandler.java
@@ -1,0 +1,37 @@
+package fundamentals.server.handlers;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+/**
+ * Will handle the endpoint "/ui/build/{id}" and will send the build.html file back to the user.
+ */
+public class UIBuildHandler extends AbstractHandler {
+
+    public static final String UI_BUILD_FILE = "public/build.html";
+
+    @Override
+    public void handle(String target,
+                       Request baseRequest,
+                       HttpServletRequest request,
+                       HttpServletResponse response)
+            throws IOException, ServletException {
+        response.setContentType("text/html;charset=utf-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        baseRequest.setHandled(true);
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(UI_BUILD_FILE))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                response.getWriter().println(line);
+            }
+        }
+    }
+}

--- a/src/main/java/fundamentals/server/handlers/WebhookHandler.java
+++ b/src/main/java/fundamentals/server/handlers/WebhookHandler.java
@@ -125,7 +125,7 @@ public class WebhookHandler extends AbstractHandler {
             // Check if the project compiles.
             Boolean didCompile = compiler.compile();
 
-            // Store compile logs in the JSON file.
+            // Store compile logs in the JSON object.
             for (String log : compiler.getCompileOutput())
                 newBuild.getJSONArray("compile_logs").put(log);
 
@@ -138,7 +138,7 @@ public class WebhookHandler extends AbstractHandler {
                 Tester tester = new Tester(manager.getRepoDir(), new Bash());
                 Boolean testsPassed = tester.run();
 
-                // Store test logs in the JSON file.
+                // Store test logs in the JSON object.
                 for (String log : tester.getTestOutput())
                     newBuild.getJSONArray("test_logs").put(log);
 
@@ -158,7 +158,7 @@ public class WebhookHandler extends AbstractHandler {
                 apiRequest = api.setCommitStatusError("Compile error", targetUrl);
             }
 
-            // The build has finished store the time and save the build to disk.
+            // The build has finished, store the build ended timestamp and save the build to disk.
             newBuild.put("build_ended", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()));
             storage.saveToDisk();
 

--- a/src/main/java/fundamentals/server/handlers/WebhookHandler.java
+++ b/src/main/java/fundamentals/server/handlers/WebhookHandler.java
@@ -1,6 +1,7 @@
 package fundamentals.server.handlers;
 
 
+import fundamentals.server.BuildStorage;
 import fundamentals.server.Environment;
 import fundamentals.server.SecurityManager;
 import fundamentals.server.Tester;
@@ -9,10 +10,6 @@ import fundamentals.server.gitTooling.GithubCommitAPIRequest;
 import fundamentals.server.gitTooling.RepoManager;
 import fundamentals.server.helpers.Bash;
 import fundamentals.server.helpers.Compiler;
-
-
-import fundamentals.server.BuildStorage;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,7 +21,14 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
+/**
+ * The {@code WebhookHandler} will handle requests on the /webhook endpoint. These requests will come from Github
+ * and indicates that an event has occurred. We are especially interested in listening to the "push" event which is when a
+ * new commit has been pushed.
+ */
 public class WebhookHandler extends AbstractHandler {
 
     private final BuildStorage storage;
@@ -56,14 +60,13 @@ public class WebhookHandler extends AbstractHandler {
             response.setStatus(HttpServletResponse.SC_OK);
             baseRequest.setHandled(true);
             System.out.println("Ping event");
-        }
-        else if (event.equals("push")) {
+        } else if (event.equals("push")) {
             response.setStatus(HttpServletResponse.SC_OK);
             baseRequest.setHandled(true);
 
             // Read the body and parse it to a JSON object.
             StringBuilder body = new StringBuilder();
-            try(BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     body.append(line);
@@ -73,6 +76,7 @@ public class WebhookHandler extends AbstractHandler {
             JSONObject root = new JSONObject(body.toString());
 
             String owner = root.getJSONObject("repository").getJSONObject("owner").getString("name");
+            String branch = root.getString("ref").substring("refs/heads/".length());
             String repository = root.getJSONObject("repository").getString("name");
 
             try {
@@ -84,7 +88,6 @@ public class WebhookHandler extends AbstractHandler {
                 return;
             }
 
-
             String commitHash = root.getString("after");
 
             System.out.println("Push event: ");
@@ -93,15 +96,18 @@ public class WebhookHandler extends AbstractHandler {
             System.out.println("Commit:" + commitHash);
 
             // Create a build ID, build date and set build status = pending. Store this in a JSONObject in main-memory.
-            JSONObject newBuild = storage.addNewBuild(owner, repository, commitHash);
+            JSONObject newBuild = storage.addNewBuild(owner, repository, branch, commitHash);
             String buildID = newBuild.getString("build_id");
 
             String username = environment.getValue("USERNAME");
             String personalAccessToken = environment.getValue("PERSONAL_ACCESS_TOKEN");
             String hostname = environment.getValue("HOSTNAME");
 
+            // The URL Github will show the user associated with the Github status.
+            String targetUrl = "http://" + hostname + "/build/" + buildID;
+
             GithubCommitAPI api = new GithubCommitAPI(owner, repository, commitHash, username, personalAccessToken);
-            GithubCommitAPIRequest apiRequest = api.setCommitStatusPending("Compiling and running tests...", "http://" + hostname + "/build/" + buildID);
+            GithubCommitAPIRequest apiRequest = api.setCommitStatusPending("Compiling and running tests...", targetUrl);
 
             if (apiRequest.send()) {
                 System.out.println("Updated commit status to pending for commit: " + commitHash);
@@ -111,41 +117,59 @@ public class WebhookHandler extends AbstractHandler {
 
             RepoManager manager = new RepoManager(body.toString(), environment);
             Compiler compiler = new Compiler(manager.getRepoDir(), new Bash());
-            Tester tester = new Tester(manager.getRepoDir(), new Bash());
 
+            // Clone the repo and switch to the modified branch.
             manager.cloneRepo();
             manager.checkoutBranch();
 
+            // Check if the project compiles.
             Boolean didCompile = compiler.compile();
+
+            // Store compile logs in the JSON file.
+            for (String log : compiler.getCompileOutput())
+                newBuild.getJSONArray("compile_logs").put(log);
 
             if (didCompile) {
                 System.out.println("Did compile without error");
-            } else {
-                System.err.println("compilation failed");
-            }
 
-            Boolean testsPassed = tester.run();
+                newBuild.put("compile_status", "success");
 
-            if (testsPassed) {
-                System.out.println("testsuite executed without any failures");
+                // Check if all tests pass.
+                Tester tester = new Tester(manager.getRepoDir(), new Bash());
+                Boolean testsPassed = tester.run();
 
-                apiRequest = api.setCommitStatusSuccess("tests passed", "http://" + hostname + "/build/" + buildID);
-                if (apiRequest.send()) {
-                    System.out.println("Updated commit status to success for commit: " + commitHash);
+                // Store test logs in the JSON file.
+                for (String log : tester.getTestOutput())
+                    newBuild.getJSONArray("test_logs").put(log);
+
+                if (testsPassed) {
+                    System.out.println("Testsuite executed without any failures");
+                    newBuild.put("test_status", "success");
+                    apiRequest = api.setCommitStatusSuccess("Tests passed", targetUrl);
                 } else {
-                    System.out.println("Failed to update commit status for: " + commitHash);
+                    System.out.println("Testsuite failed");
+                    newBuild.put("test_status", "failure");
+                    apiRequest = api.setCommitStatusFailure("Tests failed", targetUrl);
                 }
             } else {
-                System.out.println("testsuite failed");
-
-                apiRequest = api.setCommitStatusError("tests failed", "http://" + hostname + "/build/" + buildID);
-                if (apiRequest.send()) {
-                    System.out.println("Updated commit status to failed for commit: " + commitHash);
-                } else {
-                    System.out.println("Failed to update commit status for: " + commitHash);
-                }
+                System.err.println("Compilation failed");
+                newBuild.put("compile_status", "error");
+                newBuild.put("test_status", "failure"); // No need to run the tests if the project did not compile.
+                apiRequest = api.setCommitStatusError("Compile error", targetUrl);
             }
 
+            // The build has finished store the time and save the build to disk.
+            newBuild.put("build_ended", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()));
+            storage.saveToDisk();
+
+            // Update the commit status for the commit on Github.
+            if (apiRequest.send()) {
+                System.out.println("Updated commit status for commit: " + commitHash);
+            } else {
+                System.out.println("Failed to update commit status for: " + commitHash);
+            }
+
+            // Remove the cloned repo from disk (no need to store this anymore because the build has completed).
             manager.cleanUp();
         }
     }

--- a/src/main/java/fundamentals/server/handlers/WebhookHandler.java
+++ b/src/main/java/fundamentals/server/handlers/WebhookHandler.java
@@ -104,7 +104,7 @@ public class WebhookHandler extends AbstractHandler {
             String hostname = environment.getValue("HOSTNAME");
 
             // The URL Github will show the user associated with the Github status.
-            String targetUrl = "http://" + hostname + "/build/" + buildID;
+            String targetUrl = "http://" + hostname + "/ui/build/" + buildID;
 
             GithubCommitAPI api = new GithubCommitAPI(owner, repository, commitHash, username, personalAccessToken);
             GithubCommitAPIRequest apiRequest = api.setCommitStatusPending("Compiling and running tests...", targetUrl);

--- a/src/main/java/fundamentals/server/helpers/Bash.java
+++ b/src/main/java/fundamentals/server/helpers/Bash.java
@@ -16,9 +16,10 @@ public class Bash {
 
     /**
      * Spawns a process by executing a command, and blocks while the process is running.
+     *
      * @param cmdArray the command to be executed, each argument a separate element in the array
-     * @param envArr an array of environment variables for the execution
-     * @param dir the working directory to execute in
+     * @param envArr   an array of environment variables for the execution
+     * @param dir      the working directory to execute in
      * @return true iff the process exited normally with exit code 0
      */
     public boolean execute(String[] cmdArray, String[] envArr, File dir) {

--- a/src/main/java/fundamentals/server/helpers/Compiler.java
+++ b/src/main/java/fundamentals/server/helpers/Compiler.java
@@ -1,6 +1,6 @@
 package fundamentals.server.helpers;
 
-import java.io.*;
+import java.io.File;
 import java.util.List;
 
 /**
@@ -18,16 +18,24 @@ public class Compiler {
 
     /**
      * Compiles the repository using maven, and returns true if the exit code from "mvn compile" is 0.
+     *
      * @return true if the compilation was successful, as determined by the exit code of "mvn compile"
      */
     public boolean compile() {
-        String[] mavenCmd = {"mvn", "compile"};
+        String[] mavenCmd;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            mavenCmd = new String[] {"mvn.cmd", "compile"};
+        } else {
+            mavenCmd = new String[] {"mvn", "compile"};
+        }
 
         return shell.execute(mavenCmd, null, repoDir);
     }
 
     /**
      * Get the output from the compilation command
+     *
      * @return a list of the lines of the compilation output
      */
     public List<String> getCompileOutput() {

--- a/src/test/java/fundamentals/server/BuildStorageTest.java
+++ b/src/test/java/fundamentals/server/BuildStorageTest.java
@@ -98,10 +98,11 @@ public class BuildStorageTest {
     @DisplayName("Create a new build test")
     void createNewBuildTest() {
         BuildStorage storage = BuildStorage.loadBuildStorageFile(BUILDS_TEST_FILE);
-        JSONObject newBuild = storage.addNewBuild("new-owner", "new-repo", "new-commit");
+        JSONObject newBuild = storage.addNewBuild("new-owner", "new-repo", "new-branch", "new-commit");
 
         assertEquals("new-owner", newBuild.getString("owner"));
         assertEquals("new-repo", newBuild.getString("repository"));
+        assertEquals("new-branch", newBuild.getString("branch"));
         assertEquals("new-commit", newBuild.getString("commit"));
 
         // Ensure that it is possible to retrieve the new build from the array.

--- a/src/test/java/fundamentals/server/CompilerTest.java
+++ b/src/test/java/fundamentals/server/CompilerTest.java
@@ -33,7 +33,14 @@ public class CompilerTest {
     @Test
     @DisplayName("Test compiler runs mvn compile")
     void testThatTesterWillExecuteMavenCompile() {
-        String[] cmd = {"mvn", "compile"};
+        String[] cmd;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            cmd = new String[] {"mvn.cmd", "compile"};
+        } else {
+            cmd = new String[] {"mvn", "compile"};
+        }
+
         File dir = new File(PATH_TO_WORKING_DIRECTORY);
         Bash shell = mock(Bash.class);
 
@@ -48,7 +55,14 @@ public class CompilerTest {
     @Test
     @DisplayName("Test compile returns true if exit code is zero")
     void testThatCompileReturnsTrueIfExitCodeFromMavenCompileIsZero() {
-        String[] cmd = {"mvn", "compile"};
+        String[] cmd;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            cmd = new String[] {"mvn.cmd", "compile"};
+        } else {
+            cmd = new String[] {"mvn", "compile"};
+        }
+
         File dir = new File(PATH_TO_WORKING_DIRECTORY);
         Bash shell = mock(Bash.class);
 
@@ -63,7 +77,14 @@ public class CompilerTest {
     @Test
     @DisplayName("Test compile returns false if exit code is not zero")
     void testThatCompileReturnsTrueIfNonZeroExitCodeFromMavenCompile() {
-        String[] cmd = {"mvn", "compile"};
+        String[] cmd;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            cmd = new String[] {"mvn.cmd", "compile"};
+        } else {
+            cmd = new String[] {"mvn", "compile"};
+        }
+
         File dir = new File(PATH_TO_WORKING_DIRECTORY);
         Bash shell = mock(Bash.class);
 

--- a/src/test/java/fundamentals/server/TesterTest.java
+++ b/src/test/java/fundamentals/server/TesterTest.java
@@ -32,7 +32,14 @@ public class TesterTest {
     @Test
     @DisplayName("Test that maven test is run by tester")
     void testThatTesterWillExecuteMavenTest() {
-        String[] cmd = {"mvn", "test"};
+        String[] cmd;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            cmd = new String[] {"mvn.cmd", "test"};
+        } else {
+            cmd = new String[] {"mvn", "test"};
+        }
+
         File dir = new File(PATH_TO_WORKING_DIRECTORY);
         Bash shell = mock(Bash.class);
 
@@ -47,7 +54,14 @@ public class TesterTest {
     @Test
     @DisplayName("Test that a non-zero exit code produces a failing test")
     void testThatANonZeroExitCodeProducesAFailingTest() {
-        String[] cmd = {"mvn", "test"};
+        String[] cmd;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            cmd = new String[] {"mvn.cmd", "test"};
+        } else {
+            cmd = new String[] {"mvn", "test"};
+        }
+
         File dir = new File(PATH_TO_WORKING_DIRECTORY);
         Bash shell = mock(Bash.class);
 


### PR DESCRIPTION
Two new handlers have been added `UIBuildAllHandler` and `UIBuildHandler` they both just respond with a single HTML document that visualizes the JSON build data. I also added so that the JSON build data gets updated with statuses, logs, and dates. When the build has been completed the JSON data will be written to disk and we will therefore have persistent storage of all our builds. 

Lastly to solve the problem that the commands `mvn compile` and `mvn test` do not work on Windows I added a check if the platform is Windows then we run `mvn.cmd compile` and `mvn.cmd test` instead.

This PR should give us a fully working application that keeps a persistent storage of builds and offers a GUI for the user. If the code does not work for you, then contact me :)